### PR TITLE
fix: feature detection cannot be used for architectures other than x86

### DIFF
--- a/multiversion-macros/src/target.rs
+++ b/multiversion-macros/src/target.rs
@@ -134,7 +134,7 @@ impl Target {
             }
         );
         quote! {
-            true #( && std::#is_feature_detected!(#feature) )*
+            true #( && std::arch::#is_feature_detected!(#feature) )*
         }
     }
 }


### PR DESCRIPTION
Thank you for the useful project.

There is only `is_x86_feature_detected!` in `std::*`, and others are in `std::arch::*`. So it can't detect feature in other architectures.