### PR TITLE
Add dispatcher that returns function pointer

### DIFF
--- a/multiversion-macros/src/multiversion.rs
+++ b/multiversion-macros/src/multiversion.rs
@@ -122,7 +122,7 @@ pub(crate) fn make_multiversioned_fn(
                         "x86+sse4.2",
                         "x86+sse2",
                         "aarch64+neon",
-                        // "arm+neon",
+                        "arm+neon",
                         // "mips+msa",
                         // "mips64+msa",
                         // "powerpc+vsx",
@@ -172,6 +172,7 @@ pub(crate) fn make_multiversioned_fn(
                 "static" => Ok(DispatchMethod::Static),
                 "direct" => Ok(DispatchMethod::Direct),
                 "indirect" => Ok(DispatchMethod::Indirect),
+                "pointer" => Ok(DispatchMethod::FunctionPointer),
                 _ => Err(Error::new(
                     s.span(),
                     "expected `default`, `static`, `direct`, or `indirect`",


### PR DESCRIPTION
I found this functionality useful when creating a [noise library](https://github.com/formulaicgame/fmc_noise/) and want to know if you would add something like it. Usecase here is I have many noise functions that each have their own multiversion derive. They are composed at runtime and called in series to fill an array with noise. Going through the dispatcher for each function call adds too much overhead, so I instead want to call the dispatcher once while constructing and get the function pointer so I can skip it when computing.

No intention to merge this, just easier to display through a pr.