### PR TITLE
Use BTreeMap for deterministic cfg target order (fixes nondeterministic SVH)

### DIFF
--- a/multiversion-macros/src/dispatcher.rs
+++ b/multiversion-macros/src/dispatcher.rs
@@ -1,7 +1,7 @@
 use crate::{target::Target, util};
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use syn::{
     parse_quote, Attribute, Block, Error, Expr, Ident, ItemFn, Result, Signature, Visibility,
 };
@@ -407,12 +407,15 @@ impl Dispatcher {
         //   dispatch entirely and call the default function.
         //
         // In these cases, the default function is called instead.
+        // BTreeMap (not HashMap): iteration and `.keys()` order below are spliced into
+        // `#[cfg(...)]` tokens, so the order must be deterministic across proc-macro
+        // invocations or the generated crate's Svh varies build-to-build (rust#89904).
         let best_targets = self
             .targets
             .iter()
             .rev()
             .map(|t| (t.arch(), t))
-            .collect::<HashMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
         let mut skips = Vec::new();
         for (arch, target) in best_targets.iter() {
             let feature = target.features();


### PR DESCRIPTION
`Dispatcher` collects its targets into a `HashMap` and then splices the iteration order into the generated code:

```rust
let best_targets = self.targets.iter().rev().map(|t| (t.arch(), t)).collect::<HashMap<_, _>>();
let mut skips = Vec::new();
for (arch, target) in best_targets.iter() { /* … → skips */ }
let specified_arches = best_targets.keys().collect::<Vec<_>>();
```

Both `best_targets.iter()` (→ `skips`) and `best_targets.keys()` (→ `specified_arches`) walk a `HashMap`, whose order is randomized per process. Those orderings end up inside the generated `#[cfg(...)]` predicates, so the expanded tokens — and therefore the SVH of any crate that uses `#[multiversion]` — change between otherwise-identical builds. It's the proc-macro flavor of rust-lang/rust#89904: rustc canonicalizes its own SVH inputs, but it can't defend against a macro that emits tokens in a random order.

I ran into this with a content-addressed build: a crate using `#[multiversion(targets = "simd")]` produced a different `.rmeta` hash on ~7 of 8 clean rebuilds on the same machine, which breaks crate caching/reuse.

The fix is to use a `BTreeMap` for `best_targets`. The key is `&str` (`Ord`), so both the `iter()` and `keys()` orders become deterministic. The generated `cfg` predicates are equivalent, so there's no behavior change — only the ordering is stabilized.

Verified by building such a crate repeatedly: identical `.rmeta` every time with the patch, versus a different one on almost every build without it, on both x86_64 and aarch64.
